### PR TITLE
refactor: use uv for dependency management in GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,21 +24,26 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
 
-    - name: Cache pip packages
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Cache uv packages
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        path: |
+          ~/.cache/uv
+          ~/.cache/pip
+        key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-uv-
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov pytest-asyncio httpx fastapi uvicorn dependency-injector hatchling pydantic
-        pip install -e .
+        uv pip install pytest pytest-cov pytest-asyncio httpx fastapi uvicorn dependency-injector hatchling pydantic
+        uv pip install -e .
 
     - name: Run ${{ matrix.test-type }} tests
       env:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         uv venv
+        source .venv/bin/activate
         uv pip install pytest pytest-cov pytest-asyncio httpx fastapi uvicorn dependency-injector hatchling pydantic
         uv pip install -e .
 
@@ -51,6 +52,7 @@ jobs:
         PYTHONPATH: ${{ github.workspace }}
         PYTHONUNBUFFERED: 1
       run: |
+        source .venv/bin/activate
         pytest tests/${{ matrix.test-type }}/ -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,6 +42,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        uv venv
         uv pip install pytest pytest-cov pytest-asyncio httpx fastapi uvicorn dependency-injector hatchling pydantic
         uv pip install -e .
 


### PR DESCRIPTION
## 変更内容

- GitHub Actionsのワークフローで`uv`を使用するように変更
- `uv`のインストールステップを追加
- キャッシュ設定を`uv`用に更新
- 依存関係のインストールコマンドを`uv pip install`に変更

## 変更理由

- `uv`は`pip`よりも高速なパッケージマネージャー
- 依存関係のインストール時間を短縮
- キャッシュの効率を改善

## テスト結果
- ローカル環境で`uv`を使用した依存関係のインストールを確認
- GitHub Actionsのワークフローが正常に動作することを確認